### PR TITLE
Trace a request using Jaeger

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "body-parser": "^1.18.2",
     "boom": "^5.2.0",
     "ioredis": "^3.1.4",
+    "jaeger-client": "^3.6.0",
     "joi": "^11.1.1",
     "koa": "^2.3.0",
     "koa-bodyparser": "^4.2.0",
     "koa-router": "^7.2.1",
     "lodash": "^4.17.4",
-    "object-hash": "^1.1.8"
+    "object-hash": "^1.1.8",
+    "opentracing": "^0.14.1"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.12",

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -36,7 +36,7 @@ export default class Server {
     this.router = new Router()
     this.router.post('/rpc', async ctx => {
       try {
-        const result = await this.executeEndpoint(ctx.request.body.topic, ctx.request.body.payload)
+        const result = await this.executeEndpoint(ctx.request.body.topic, ctx.request.body.payload, ctx.headers)
         ctx.body = { payload: result }
       } catch (err) {
         const boomError = Boom.boomify(err, { override: false })
@@ -108,7 +108,7 @@ export default class Server {
     return false
   }
 
-  private async executeEndpoint (topic: string, payload: object) {
+  private async executeEndpoint (topic: string, payload: object, headers?: object) {
     const endpoint = this.endpointMap.get(topic)
 
     if (!endpoint) throw Boom.badRequest('Invalid topic')
@@ -133,7 +133,7 @@ export default class Server {
     try {
       const delegator = {
         makeDelegateRequestAsync: (topic: string, payload: any, target: string) => {
-          return makeRequest(topic, payload, target)
+          return makeRequest(topic, payload, target, headers)
         }
       }
       result = await Bluebird

--- a/src/makeRequest.ts
+++ b/src/makeRequest.ts
@@ -1,10 +1,45 @@
 import axios from 'axios'
 import * as Boom from 'boom'
+import * as jaeger from 'jaeger-client'
 import * as _ from 'lodash'
+import * as opentracing from 'opentracing'
 
-async function makeRequest (topic: string, payload: any, target: string) {
-  return axios.post(target, { topic, payload })
-    .then(response => response.data.payload)
+const config = {
+  serviceName: 'chayen',
+  sampler: {
+    type: 'const',
+    param: 1,
+    host: 'localhost',
+    port: 5775,
+    refreshIntervalMs: 500
+  },
+  reporter: {
+    flushIntervalMs: 500
+  }
+}
+
+const options = {
+  tags: {
+    service_version: '1.0.0' // could be sent from the caller?
+  }
+}
+
+async function makeRequest (topic: string, payload: any, target: string, headers?: any) {
+  const tracer = jaeger.initTracer(config, options) as opentracing.Tracer
+  let span
+  if (headers) {
+    const wireCtx = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers)
+    span = tracer.startSpan(topic, { childOf: wireCtx as opentracing.SpanContext })
+  } else {
+    span = tracer.startSpan(topic)
+  }
+  const carrier = {}
+  tracer.inject(span.context(), opentracing.FORMAT_HTTP_HEADERS, carrier)
+  return axios.post(target, { topic, payload }, { headers: carrier })
+    .then(response => {
+      span.finish()
+      return response.data.payload
+    })
     .catch(err => {
       const errData = _.get(err, 'response.data')
       if (errData) {
@@ -13,6 +48,8 @@ async function makeRequest (topic: string, payload: any, target: string) {
           _.get(errData, 'output.payload.message')
         )
       }
+      span.addTags({ error: true })
+      span.finish()
       throw err
     })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,6 +160,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-color@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-color/-/ansi-color-0.2.1.tgz#3e75c037475217544ed763a8db5709fa9ae5bf9a"
+
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -523,6 +527,14 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+bufrw@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bufrw/-/bufrw-1.2.1.tgz#93f222229b4f5f5e2cd559236891407f9853663b"
+  dependencies:
+    ansi-color "^0.2.1"
+    error "^7.0.0"
+    xtend "^4.0.0"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -823,6 +835,13 @@ error-ex@^1.2.0:
 error-inject@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
+
+error@7.0.2, error@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/error/-/error-7.0.2.tgz#a5f75fff4d9926126ddac0ea5dc38e689153cb02"
+  dependencies:
+    string-template "~0.2.1"
+    xtend "~4.0.0"
 
 es-abstract@^1.5.0:
   version "1.8.2"
@@ -1521,6 +1540,15 @@ istanbul-reports@^1.1.2:
   dependencies:
     handlebars "^4.0.3"
 
+jaeger-client@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.6.0.tgz#5659f522776298eea8ed768741dc71978ba69a98"
+  dependencies:
+    node-int64 "^0.4.0"
+    opentracing "^0.13.0"
+    thriftrw "^3.5.0"
+    xorshift "^0.2.0"
+
 jest-changed-files@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
@@ -2157,6 +2185,10 @@ lodash@^4.14.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+long@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2385,6 +2417,14 @@ once@^1.3.0, once@^1.3.3, once@^1.4.0:
 only@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
+
+opentracing@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.13.0.tgz#6a341442f09d7d866bc11ed03de1e3828e3d6aab"
+
+opentracing@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.1.tgz#40d278beea417660a35dd9d3ee76511ffa911dcd"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2875,6 +2915,10 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
+string-template@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -3006,6 +3050,14 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+thriftrw@^3.5.0:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/thriftrw/-/thriftrw-3.11.1.tgz#5a2f5165d665bb195e665e5b5b9f8897dac23acc"
+  dependencies:
+    bufrw "^1.2.1"
+    error "7.0.2"
+    long "^2.4.0"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -3282,7 +3334,11 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.1:
+xorshift@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
+
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
🚧 🚧 🚧

To test this
```bash
docker run -d -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p5775:5775/udp -p6831:6831/udp -p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 -p9411:9411 jaegertracing/all-in-one:latest
yarn
yarn test
open http://localhost:16686/search
```